### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,19 +1,19 @@
 # Syntax Colouring for Buttons library
 
 # Classes, datatypes & C++ keywords (K1)
-ButtonsClass			KEYWORD1
-Buttons					KEYWORD1
+ButtonsClass	KEYWORD1
+Buttons	KEYWORD1
 
 # Methods & Functions (K2)
-begin					KEYWORD2
-end						KEYWORD2
-clicked					KEYWORD2
-released				KEYWORD2
-down					KEYWORD2
-up						KEYWORD2
-changed					KEYWORD2
-clearChangeFlag			KEYWORD2
-numberOfButtons			KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+clicked	KEYWORD2
+released	KEYWORD2
+down	KEYWORD2
+up	KEYWORD2
+changed	KEYWORD2
+clearChangeFlag	KEYWORD2
+numberOfButtons	KEYWORD2
 
 # setup and loop functions, and Serial keywords (K3)
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords